### PR TITLE
releasing binaries for darwin and linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,14 @@ on:
       - 'v*' # Push events to matching v*, i.e. v0.1, v0.2
 
 jobs:
-  build:
-    name: Build and Upload Release Asset
+  release:
+    name: Create a Release
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Build project
-        run: |
-          make release
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -26,13 +25,47 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
+  build_linux:
+    name: Build and Upload Release Asset (Linux)
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v3
+      - name: Build project
+        run: |
+          make release
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./out/convert.tar.gz
-          asset_name: convert.tar.gz
+          asset_name: convert-linux-amd64.tar.gz
+          asset_content_type: application/gzip
+  build_macos:
+    name: Build and Upload Release Asset (MacOS)
+    runs-on: macos-latest
+    needs: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v3
+      - name: Build project
+        run: |
+          make release
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./out/convert.tar.gz
+          asset_name: convert-darwin-amd64.tar.gz
           asset_content_type: application/gzip


### PR DESCRIPTION
**This PR enables the build and release for both OS (Linux and MacOS).**

When I tried to use the [migrate_addon](https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/blob/main/scripts/migration/migrate-addon) in a macos system I faced the problem of the script only works for linux and the downloaded `convert` binary was only available for linux as well.

It was easy to run the script on a macos simply installing `coreutils` and building the `convert` binary for `darwin` OS. With that, this PR proposes to have binaries for both OS.

If you guys agree with that approach I will also open a Pull Request for `migrate-addon` to enable macos usage.